### PR TITLE
Add support for Maya 2017 and NUKE

### DIFF
--- a/config_maya.ocio
+++ b/config_maya.ocio
@@ -1,0 +1,188 @@
+# Filmlike Dynamic Range LUT configuration for
+# Blender. Crafted by Troy James Sobotka with
+# special thanks and feedback from Guillermo
+# Espertino, Claudio Rocha, Bassam Kurdali, Eugenio
+# Pignataro, Henri Hebeisen, Jason Clarke,
+# Haarm-Peter Duiker, Thomas Mansencal, and Timothy
+# Lottes.
+# Modified by Maxime Roz to work with Maya 2017 (this is a temporary version until Maya get fixed).
+
+ocio_profile_version: 1
+
+search_path: "luts:looks"
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: linear
+  reference: linear
+  scene_linear: linear
+  data: noncol
+  compositing_log: filmic
+  color_timing: filmic
+  default_byte: srgb
+  default_float: linear
+  default_sequencer: srgb
+  color_picking: srgb
+  texture_paint: srgb
+  matte_paint: filmic
+
+displays:
+  sRGB / BT.709:
+    - !<View> {name: sRGB EOTF, colorspace: srgb}
+    - !<View> {name: BT.1886 EOTF, colorspace: bt1886}
+    - !<View> {name: Non-Colour Data, colorspace: noncol}
+    - !<View> {name: Linear Raw, colorspace: linear}
+    - !<View> {name: Filmic Log Encoding Base, colorspace: filmic}
+    - !<View> {name: Filmic Very High Contrast, colorspace: filmic, look: +Very High Contrast}
+    - !<View> {name: Filmic High Contrast, colorspace: filmic, look: +High Contrast}
+    - !<View> {name: Filmic Medium High Contrast, colorspace: filmic, look: +Medium High Contrast}
+    - !<View> {name: Filmic Very Low Contrast, colorspace: filmic, look: +Very Low Contrast}
+    - !<View> {name: Filmic Medium Low Contrast, colorspace: filmic, look: +Medium Low Contrast}
+    - !<View> {name: Filmic Low Contrast, colorspace: filmic, look: +Low Contrast}
+    - !<View> {name: Filmic Base Contrast, colorspace: filmic, look: +baseContrast}
+    - !<View> {name: Filmic False Colour, colorspace: filmic, look: +False Colour}
+#    - !<View> {name: Debug, colorspace: Debug}
+
+  None:
+    - !<View> {name: No View, colorspace: noncol}
+
+active_displays: [sRGB / BT.709]
+active_views: [Filmic Base Contrast, Filmic Medium High Contrast, sRGB EOTF, Linear Raw]
+
+colorspaces:
+  - !<ColorSpace>
+    name: linear
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      ITU BT.709 primaries based scene referred linear space.
+    isdata: false
+    allocation: lg2
+    allocationvars: [-12.473931188, 12.526068812]
+
+#  - !<ColorSpace>
+#    name: Debug
+#    family:
+#    equalitygroup:
+#    bitdepth: 32f
+#    description: |
+#      Debug purposes only. Do not use.
+#    isdata: false
+#    allocation: lg2
+#    allocationvars: [-12.473931188, 12.526068812]
+#    from_reference: !<GroupTransform>
+#          children:
+#              - !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 12.526068812]} #[-12.473931188, 7.526068812]}
+#              - !<AllocationTransform> {allocation: uniform, vars: [0, 0.66]} #0.825
+
+  - !<ColorSpace>
+    name: filmic
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range.
+    isdata: false
+    allocation: lg2
+    allocationvars: [-12.473931188, 12.526068812]
+    from_reference: !<GroupTransform>
+        children:
+            - !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 12.526068812]}
+            - !<FileTransform> {src: desat65cube.spi3d, interpolation: best}
+            - !<AllocationTransform> {allocation: uniform, vars: [0, 0.66]}
+    to_reference: !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 4.026068812], direction: inverse}
+
+#  - !<ColorSpace>
+#    name: Desat Log Encoding
+#    family:
+#    equalitygroup:
+#    bitdepth: 32f
+#    description: |
+#        Desaturation transform for proper crosstalk. Not intended for use.
+#    isdata: false
+#    allocation: lg2
+#    allocationvars: [-12.473931188, 12.526068812]
+#    to_reference: !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 12.526068812], direction: inverse}
+
+  - !<ColorSpace>
+    name: srgb
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      sRGB specification display referred Electro-Optical Transfer Function.
+    isdata: false
+    allocation: uniform
+    allocationvars: [0.0, 1.0]
+    to_reference: !<FileTransform> {src: sRGB_OETF_to_Linear.spi1d, interpolation: linear}
+
+  - !<ColorSpace>
+    name: bt1886
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      BT.1886 recommended display referred Electro-Optical Transfer Function.
+    isdata: false
+    allocation: uniform
+    allocationvars: [0.0, 1.0]
+    to_reference: !<FileTransform> {src: BT.1886_to_Linear.spi1d, interpolation: linear}
+
+  - !<ColorSpace>
+    name: noncol
+    family:
+    description: |
+        Transform to flag data as non-colour, strictly data, and avoid OCIO transforms.
+    equalitygroup:
+    bitdepth: 32f
+    isdata: true
+    allocation: uniform
+    allocationvars: [0, 1]
+
+looks:
+  - !<Look>
+    name: Greyscale
+    process_space: filmic
+    transform: !<MatrixTransform> {matrix: [0.2126729, 0.7151521, 0.0721750, 0, 0.2126729, 0.7151521, 0.0721750, 0, 0.2126729, 0.7151521, 0.0721750, 0, 0, 0, 0, 1]}
+
+  - !<Look>
+    name: False Colour
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_False_Colour.spi3d, interpolation: best}
+
+  - !<Look>
+    name: Very High Contrast
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_to_1.20_1-00.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: High Contrast
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_to_0.99_1-0075.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Medium High Contrast
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_to_0-85_1-011.spi1d, interpolation: best}
+
+  - !<Look>
+    name: baseContrast
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_to_0-70_1-03.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Medium Low Contrast
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_to_0-60_1-04.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Low Contrast
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_to_0-48_1-09.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Very Low Contrast
+    process_space: filmic
+    transform: !<FileTransform> {src: Filmic_to_0-35_1-30.spi1d, interpolation: linear}

--- a/config_nuke.ocio
+++ b/config_nuke.ocio
@@ -1,0 +1,189 @@
+# Filmlike Dynamic Range LUT configuration for
+# Blender. Crafted by Troy James Sobotka with
+# special thanks and feedback from Guillermo
+# Espertino, Claudio Rocha, Bassam Kurdali, Eugenio
+# Pignataro, Henri Hebeisen, Jason Clarke,
+# Haarm-Peter Duiker, Thomas Mansencal, and Timothy
+# Lottes.
+
+ocio_profile_version: 1
+
+search_path: "luts:looks"
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+
+description: A filmlike dynamic range encoding set for Blender
+
+roles:
+  default: Linear
+  reference: Linear
+  scene_linear: Linear
+  data: Non-Colour Data
+  compositing_log: Filmic Log Encoding
+  color_timing: Filmic Log Encoding
+  default_byte: sRGB EOTF
+  default_float: Linear
+  default_sequencer: sRGB EOTF
+  color_picking: sRGB EOTF
+  texture_paint: sRGB EOTF
+  matte_paint: Filmic Log Encoding
+
+displays:
+  sRGB / BT.709:
+    - !<View> {name: sRGB EOTF, colorspace: sRGB EOTF}
+    - !<View> {name: BT.1886 EOTF, colorspace: BT.1886 EOTF}
+    - !<View> {name: Non-Colour Data, colorspace: Non-Colour Data}
+    - !<View> {name: Linear Raw, colorspace: Linear}
+    - !<View> {name: Filmic Log Encoding Base, colorspace: Filmic Log Encoding}
+    - !<View> {name: Filmic Very High Contrast, colorspace: Filmic Log Encoding, look: +Very High Contrast}
+    - !<View> {name: Filmic High Contrast, colorspace: Filmic Log Encoding, look: +High Contrast}
+    - !<View> {name: Filmic Medium High Contrast, colorspace: Filmic Log Encoding, look: +Medium High Contrast}
+    - !<View> {name: Filmic Very Low Contrast, colorspace: Filmic Log Encoding, look: +Very Low Contrast}
+    - !<View> {name: Filmic Medium Low Contrast, colorspace: Filmic Log Encoding, look: +Medium Low Contrast}
+    - !<View> {name: Filmic Low Contrast, colorspace: Filmic Log Encoding, look: +Low Contrast}
+    - !<View> {name: Filmic Base Contrast, colorspace: Filmic Log Encoding, look: +Base Contrast}
+    - !<View> {name: Filmic False Colour, colorspace: Filmic Log Encoding, look: +False Colour}
+#    - !<View> {name: Debug, colorspace: Debug}
+
+  None:
+    - !<View> {name: No View, colorspace: Non-Colour Data}
+
+active_displays: [sRGB / BT.709, None]
+#active_views: [Filmic Log Encoding Base, sRGB EOTF, Non-Colour Data, Linear Raw, No View]
+
+colorspaces:
+  - !<ColorSpace>
+    name: Linear
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      ITU BT.709 primaries based scene referred linear space.
+    isdata: false
+    allocation: lg2
+    allocationvars: [-12.473931188, 12.526068812]
+
+#  - !<ColorSpace>
+#    name: Debug
+#    family:
+#    equalitygroup:
+#    bitdepth: 32f
+#    description: |
+#      Debug purposes only. Do not use.
+#    isdata: false
+#    allocation: lg2
+#    allocationvars: [-12.473931188, 12.526068812]
+#    from_reference: !<GroupTransform>
+#          children:
+#              - !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 12.526068812]} #[-12.473931188, 7.526068812]}
+#              - !<AllocationTransform> {allocation: uniform, vars: [0, 0.66]} #0.825
+
+  - !<ColorSpace>
+    name: Filmic Log Encoding
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range.
+    isdata: false
+    allocation: lg2
+    allocationvars: [-12.473931188, 12.526068812]
+    from_reference: !<GroupTransform>
+        children:
+            - !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 12.526068812]}
+            - !<FileTransform> {src: desat65cube.spi3d, interpolation: best}
+            - !<AllocationTransform> {allocation: uniform, vars: [0, 0.66]}
+    to_reference: !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 4.026068812], direction: inverse}
+
+#  - !<ColorSpace>
+#    name: Desat Log Encoding
+#    family:
+#    equalitygroup:
+#    bitdepth: 32f
+#    description: |
+#        Desaturation transform for proper crosstalk. Not intended for use.
+#    isdata: false
+#    allocation: lg2
+#    allocationvars: [-12.473931188, 12.526068812]
+#    to_reference: !<AllocationTransform> {allocation: lg2, vars: [-12.473931188, 12.526068812], direction: inverse}
+
+  - !<ColorSpace>
+    name: sRGB EOTF
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      sRGB specification display referred Electro-Optical Transfer Function.
+    isdata: false
+    allocation: uniform
+    allocationvars: [0.0, 1.0]
+    to_reference: !<FileTransform> {src: sRGB_OETF_to_Linear.spi1d, interpolation: linear}
+
+  - !<ColorSpace>
+    name: BT.1886 EOTF
+    family:
+    equalitygroup:
+    bitdepth: 32f
+    description: |
+      BT.1886 recommended display referred Electro-Optical Transfer Function.
+    isdata: false
+    allocation: uniform
+    allocationvars: [0.0, 1.0]
+    to_reference: !<FileTransform> {src: BT.1886_to_Linear.spi1d, interpolation: linear}
+
+  - !<ColorSpace>
+    name: Non-Colour Data
+    family:
+    description: |
+        Transform to flag data as non-colour, strictly data, and avoid OCIO transforms.
+    equalitygroup:
+    bitdepth: 32f
+    isdata: true
+    allocation: uniform
+    allocationvars: [0, 1]
+
+looks:
+  - !<Look>
+    name: Greyscale
+    process_space: Filmic Log Encoding
+    transform: !<MatrixTransform> {matrix: [0.2126729, 0.7151521, 0.0721750, 0, 0.2126729, 0.7151521, 0.0721750, 0, 0.2126729, 0.7151521, 0.0721750, 0, 0, 0, 0, 1]}
+
+  - !<Look>
+    name: False Colour
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_False_Colour.spi3d, interpolation: best}
+
+  - !<Look>
+    name: Very High Contrast
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_to_1.20_1-00.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: High Contrast
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_to_0.99_1-0075.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Medium High Contrast
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_to_0-85_1-011.spi1d, interpolation: best}
+
+  - !<Look>
+    name: Base Contrast
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_to_0-70_1-03.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Medium Low Contrast
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_to_0-60_1-04.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Low Contrast
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_to_0-48_1-09.spi1d, interpolation: linear}
+
+  - !<Look>
+    name: Very Low Contrast
+    process_space: Filmic Log Encoding
+    transform: !<FileTransform> {src: Filmic_to_0-35_1-30.spi1d, interpolation: linear}


### PR DESCRIPTION
For Maya I had to change the names of the colorspaces.
For NUKE it's just uncommenting the lines from the Views in case people want to have separated config for each software. In the best case it shouldn't be like that but all software are still reacting differently...