### PR TITLE
Remove Luma coefficients

### DIFF
--- a/config.ocio
+++ b/config.ocio
@@ -11,7 +11,6 @@ ocio_profile_version: 1
 
 search_path: "luts:looks"
 strictparsing: true
-luma: [0.2126, 0.7152, 0.0722]
 
 description: A filmlike dynamic range encoding set for Blender
 


### PR DESCRIPTION
This config syntax is deprecated, also it only sets a value already set by OCIO so it is unnecessary.

https://opencolorio.org/userguide/config_syntax.html#luma