### PR TITLE
Remove trailing full stops from descriptions to avoid duplicates

### DIFF
--- a/config.ocio
+++ b/config.ocio
@@ -66,7 +66,7 @@ colorspaces:
     equalitygroup:
     bitdepth: 32f
     description: |
-      ITU BT.709 primaries based scene referred linear space.
+      ITU BT.709 primaries based scene referred linear space
     isdata: false
     allocation: lg2
     allocationvars: [-12.473931188, 12.526068812]
@@ -92,7 +92,7 @@ colorspaces:
     equalitygroup:
     bitdepth: 32f
     description: |
-      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range.
+      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range
     isdata: false
     allocation: lg2
     allocationvars: [-12.473931188, 12.526068812]
@@ -121,7 +121,7 @@ colorspaces:
     equalitygroup:
     bitdepth: 32f
     description: |
-      sRGB specification display referred Optical-Electro Transfer Function.
+      sRGB specification display referred Optical-Electro Transfer Function
     isdata: false
     allocation: uniform
     allocationvars: [0.0, 1.0]
@@ -147,7 +147,7 @@ colorspaces:
     equalitygroup:
     bitdepth: 32f
     description: |
-      sRGB specification display referred Optical-Electro Transfer Function with Apple DCI-P3 primaries.
+      sRGB specification display referred Optical-Electro Transfer Function with Apple DCI-P3 primaries
     isdata: false
     allocation: uniform
     allocationvars: [0.0, 1.0]
@@ -162,7 +162,7 @@ colorspaces:
     equalitygroup:
     bitdepth: 32f
     description: |
-      BT.1886 specification display referred Electro-Optical Transfer Function with REC.709 primaries.
+      BT.1886 specification display referred Electro-Optical Transfer Function with REC.709 primaries
     isdata: false
     allocation: uniform
     allocationvars: [0.0, 1.0]
@@ -174,7 +174,7 @@ colorspaces:
     equalitygroup:
     bitdepth: 32f
     description: |
-      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range with Apple P3 primaries.
+      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range with Apple P3 primaries
     isdata: false
     allocation: lg2
     allocationvars: [-12.473931188, 12.526068812]
@@ -197,7 +197,7 @@ colorspaces:
     equalitygroup:
     bitdepth: 32f
     description: |
-      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range with REC.709 primaries.
+      Log based filmic shaper with 16.5 stops of latitude, and 25 stops of dynamic range with REC.709 primaries
     isdata: false
     allocation: lg2
     allocationvars: [-12.473931188, 12.526068812]
@@ -216,7 +216,7 @@ colorspaces:
     name: Non-Colour Data
     family:
     description: |
-        Transform to flag data as non-colour, strictly data, and avoid OCIO colour specific transforms.
+        Transform to flag data as non-colour, strictly data, and avoid OCIO colour specific transforms
     equalitygroup:
     bitdepth: 32f
     isdata: true


### PR DESCRIPTION
Hello Troy, 
I don’t know if you are aware, but tooltips in Blender shouldn’t have a trailing full stop, otherwise it will appear duplicated. Some tooltips are generated from the OCIO config description fields, so this happens:

![image](https://user-images.githubusercontent.com/6894749/101211623-bf189700-3677-11eb-865d-4f03e0becb51.png)

I can’t test what happens for other programs, though.

Thanks for all your work on colour.